### PR TITLE
Try using dynamic libs first before trying static libs

### DIFF
--- a/configure
+++ b/configure
@@ -10,26 +10,35 @@ PKG_DEB_NAME="libfreetype6-dev, libpng-dev, libtiff5-dev"
 PKG_RPM_NAME="freetype-devel, libpng-devel, libtiff-devel"
 PKG_CSW_NAME="libfreetype_dev, libpng16_dev, libtiff_dev"
 PKG_BREW_NAME="freetype libpng libtiff zlib"
-PKG_TEST_HEADER="#include <ft2build.h>\n#include <png.h>\n#include <tiffio.h>"
+PKG_TEST_HEADER="#include <ft2build.h>\n#include <png.h>\n#include <tiffio.h>\n"
 PKG_LIBS="-lfreetype -lpng16 -ltiff -lz -ljpeg -lbz2"
 PKG_CFLAGS=""
 
+# Find compiler
+CC=`${R_HOME}/bin/R CMD config CC`
+CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
+CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
+
 # Use pkg-config if available
-pkg-config --version >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  PKGCONFIG_CFLAGS=`pkg-config --cflags ${PKG_CONFIG_NAME}`
-  PKGCONFIG_LIBS=`pkg-config --libs --static ${PKG_CONFIG_NAME}`
-fi
+pkg-config --version >/dev/null 2>&1 && R_HAS_PKG_CONFIG=1;
 
 # Note that cflags may be empty in case of success
 if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
   echo "Found INCLUDE_DIR and/or LIB_DIR!"
   PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
   PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
-elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
+elif [ $R_HAS_PKG_CONFIG ]; then
   echo "Found pkg-config cflags and libs!"
-  PKG_CFLAGS=${PKGCONFIG_CFLAGS}
-  PKG_LIBS=${PKGCONFIG_LIBS}
+  PKG_CFLAGS=`pkg-config --cflags ${PKG_CONFIG_NAME}`
+  PKG_LIBS=`pkg-config --libs ${PKG_CONFIG_NAME}`
+
+  # Test configuration
+  printf "$PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>&1 || R_CONFIG_ERROR=1;
+  # if the above errors try using --static
+  if [ $R_CONFIG_ERROR ]; then
+    PKG_LIBS=`pkg-config --libs --static ${PKG_CONFIG_NAME}`
+  fi
+  unset R_CONFIG_ERROR
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   brew --version 2>/dev/null
   if [ $? -eq 0 ]; then
@@ -41,17 +50,12 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   PKG_LIBS="-L$BREWDIR/opt/freetype/lib -L$BREWDIR/opt/libpng/lib -L$BREWDIR/opt/libtiff/lib -L$BREWDIR/opt/libjpeg/lib ${PKG_LIBS}"
 fi
 
-# Find compiler
-CC=`${R_HOME}/bin/R CMD config CC`
-CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
-
 # For debugging
 echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 echo "Using PKG_LIBS=$PKG_LIBS"
 
 # Test configuration
-echo "$PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>&1 || R_CONFIG_ERROR=1;
+printf "$PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>&1 || R_CONFIG_ERROR=1;
 
 # Customize the error
 if [ $R_CONFIG_ERROR ]; then

--- a/configure
+++ b/configure
@@ -20,7 +20,7 @@ CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
 CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
 
 # Use pkg-config if available
-pkg-config --version >/dev/null 2>&1 && R_HAS_PKG_CONFIG=1;
+pkg-config --exists ${PKG_CONFIG_NAME} >/dev/null 2>&1 && R_HAS_PKG_CONFIG=1;
 
 # Note that cflags may be empty in case of success
 if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then


### PR DESCRIPTION
As suggested by CRAN, first test with only dynamic libs, and only if that fails try to use static libs.

I verified this in a fedora docker container, so it should fix the issue. I would have liked to see the CRAN checks for 0.1.1 on macOS, to verify what we have works there, but I believe it should, and the travis test without homebrew should be basically equivalent to the CRAN machine for this purpose.