### PR TITLE
cleanup makevars, do not require GNU make

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,6 +4,7 @@
 ^\.Rproj\.user$
 ^\.travis\.yml$
 ^src/agg/src.*\.o$
+^src/agg/libstatagg.a$
 ^src/Makevars$
 ^appveyor\.yml$
 ^CODE_OF_CONDUCT\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ ragg.Rproj
 src/*.o
 src/*.so
 src/*.dll
+src/agg/*.a
 src/agg/src/*.o
 src/agg/src/*.so
 src/agg/src/*.dll

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Encoding: UTF-8
 RoxygenNote: 6.1.1
 SystemRequirements: 
     C++11,
-    GNU Make,
     freetype2
     libpng
 Suggests: 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,7 +1,13 @@
 PKG_CXXFLAGS = -I./agg/include @cflags@
-PKG_LIBS = -L./agg/src @libs@
+PKG_LIBS = -Lagg -lstatagg @libs@
 
-AGG_SOURCES = $(wildcard agg/src/*.cpp)
-OWN_SOURCES = $(wildcard *.cpp)
-SOURCES = $(AGG_SOURCES) $(OWN_SOURCES)
-OBJECTS = $(SOURCES:.cpp=.o)
+AGG_OBJECTS = agg/src/agg_curves.o agg/src/agg_font_freetype.o \
+	agg/src/agg_trans_affine.o agg/src/agg_vcgen_dash.o \
+	agg/src/agg_vcgen_stroke.o
+
+STATLIB = agg/libstatagg.a
+
+$(SHLIB): $(STATLIB)
+
+$(STATLIB): $(AGG_OBJECTS)
+	$(AR) rcs $(STATLIB) $(AGG_OBJECTS)


### PR DESCRIPTION
The proper way to build the bundled external library, which allows the linker to optimize out unused symbols from the external library. This is standard make syntax so you don't need GNU make.