### PR TITLE
Fix capture on big endian systems

### DIFF
--- a/src/AggDeviceCapture.h
+++ b/src/AggDeviceCapture.h
@@ -21,7 +21,9 @@ public:
   }
   SEXP capture() {
     SEXP raster = PROTECT(Rf_allocVector(INTSXP, this->width * this->height));
-    memcpy(INTEGER(raster), this->buffer, this->width * this->height * 4);
+    agg::rendering_buffer caprbuf(reinterpret_cast<agg::int8u*>(INTEGER(raster)),
+                                  this->width, this->height, this->width * 4);
+    agg::convert<pixfmt_r_capture, pixfmt_type_32>(&caprbuf, &this->rbuf);
     SEXP dims = PROTECT(Rf_allocVector(INTSXP, 2));
     INTEGER(dims)[0] = this->height;
     INTEGER(dims)[1] = this->width;

--- a/src/ragg.h
+++ b/src/ragg.h
@@ -36,8 +36,10 @@ typedef agg::pixfmt_rgba64_pre                  pixfmt_type_64;
 
 #ifdef __BIG_ENDIAN__ 
 typedef agg::pixfmt_abgr32_plain                pixfmt_r_raster;
+typedef agg::pixfmt_abgr32_pre                  pixfmt_r_capture;
 #else
 typedef agg::pixfmt_rgba32_plain                pixfmt_r_raster;
+typedef agg::pixfmt_rgba32_pre                  pixfmt_r_capture;
 #endif
 
 // pixfmt agnosting demultiplying

--- a/src/ragg.h
+++ b/src/ragg.h
@@ -34,7 +34,7 @@ typedef agg::pixfmt_rgba32_pre                  pixfmt_type_32;
 typedef agg::pixfmt_rgb48_pre                   pixfmt_type_48;
 typedef agg::pixfmt_rgba64_pre                  pixfmt_type_64;
 
-#ifdef __BIG_ENDIAN__ 
+#ifdef WORDS_BIGENDIAN
 typedef agg::pixfmt_abgr32_plain                pixfmt_r_raster;
 typedef agg::pixfmt_abgr32_pre                  pixfmt_r_capture;
 #else


### PR DESCRIPTION
R expects colours to be integers of ABGR, which on little-endian machines maps to singular bytes in RGBA order, but maps to ABGR order on bit-endian machines.

Fixes #48.