### PR TITLE
Enable autobrew in CI when needed

### DIFF
--- a/configure
+++ b/configure
@@ -30,7 +30,7 @@ if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
   PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
   PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
 elif [ "$PLATFORM" = "Darwin" ]; then
-  brew --version 2>/dev/null
+  test ! "$CI" && brew --version 2>/dev/null
   if [ $? -eq 0 ]; then
     BREWDIR=`brew --prefix`
     PKG_CFLAGS="-I$BREWDIR/include -I$BREWDIR/include/freetype2"


### PR DESCRIPTION
This will use the autobrew libs in CI setups on MacOS where the system libraries are missing.