### PR TITLE
Inspect rendered glyph bitmap before deciding how to render it to page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ragg (development version)
 
+* Fix a bug when rendering glyphs from a colour font that also provide greyscale
+  glyphs (#105)
+
 # ragg 1.2.4
 
 * Fixed a regression that turned off line mitre support (#119)

--- a/src/agg/src/agg_font_freetype.cpp
+++ b/src/agg/src/agg_font_freetype.cpp
@@ -1018,19 +1018,23 @@ namespace agg
                 
             case glyph_ren_native_color:
                 m_last_error = FT_Render_Glyph(m_cur_face->glyph, FT_RENDER_MODE_NORMAL);
-                if(m_last_error == 0)
+              
+                if(m_cur_face->glyph->bitmap.pixel_mode == FT_PIXEL_MODE_BGRA) // will fall through to grey render otherwise
                 {
-                    m_bounds.x1 = m_cur_face->glyph->bitmap_left;
-                    m_bounds.y1 = m_cur_face->glyph->bitmap_top;
-                    m_bounds.x2 = m_bounds.x1 + m_cur_face->glyph->bitmap.width;
-                    m_bounds.y2 = m_bounds.y1 - m_cur_face->glyph->bitmap.rows;
-                    m_data_size = m_cur_face->glyph->bitmap.rows * m_cur_face->glyph->bitmap.pitch; 
-                    m_data_type = glyph_data_color;
-                    m_advance_x = int26p6_to_dbl(m_cur_face->glyph->advance.x);
-                    m_advance_y = int26p6_to_dbl(m_cur_face->glyph->advance.y);
-                    return true;
+                    if(m_last_error == 0)
+                    {
+                        m_bounds.x1 = m_cur_face->glyph->bitmap_left;
+                        m_bounds.y1 = m_cur_face->glyph->bitmap_top;
+                        m_bounds.x2 = m_bounds.x1 + m_cur_face->glyph->bitmap.width;
+                        m_bounds.y2 = m_bounds.y1 - m_cur_face->glyph->bitmap.rows;
+                        m_data_size = m_cur_face->glyph->bitmap.rows * m_cur_face->glyph->bitmap.pitch; 
+                        m_data_type = glyph_data_color;
+                        m_advance_x = int26p6_to_dbl(m_cur_face->glyph->advance.x);
+                        m_advance_y = int26p6_to_dbl(m_cur_face->glyph->advance.y);
+                        return true;
+                    }
+                    break;
                 }
-                break;
                 
             case glyph_ren_native_gray8:
                 m_last_error = FT_Render_Glyph(m_cur_face->glyph, FT_RENDER_MODE_NORMAL);


### PR DESCRIPTION
Fix #105

Surprisingly some of the glyphs from the windows emoji font is rendered as grey scale bitmaps, rather than in colour. This fix will inspect the pixel mode of the rendered bitmap and fall through to grey rendering if it is not BGRA

@yutannihilation can I get you to confirm that this fix solves the reported issue on your end as well?