### PR TITLE
Ensure library link flags are unique, fixing build for Wasm/webR

### DIFF
--- a/configure
+++ b/configure
@@ -49,6 +49,9 @@ elif [ `uname` = "Darwin" ]; then
   fi
 fi
 
+# Ensure that lib link flags are unique
+PKG_LIBS=$(echo ${PKG_LIBS} | xargs -n1 | sort -u | xargs)
+
 # For debugging
 echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 echo "Using PKG_LIBS=$PKG_LIBS"


### PR DESCRIPTION
Fixes compiling with Emscripten for webR, where linking is static and so multiple instances of the same library link flag, such as `-lz`, leads to duplicate symbol errors.