### PR TITLE
Fix freetype2 compile error (#170).

### DIFF
--- a/src/agg/src/agg_font_freetype.cpp
+++ b/src/agg/src/agg_font_freetype.cpp
@@ -179,7 +179,7 @@ namespace agg
             v_control = v_start;
 
             point = outline.points + first;
-            tags  = outline.tags  + first;
+            tags  = (char*)outline.tags  + first;
             tag   = FT_CURVE_TAG(tags[0]);
 
             // A contour cannot start with a cubic control point!


### PR DESCRIPTION
Fix for #170 that seems to work.

This seems needed for new installs.