### PR TITLE
Fix pkgdown build

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -32,3 +32,4 @@ reference:
     - agg_tiff
     - agg_capture
     - agg_ppm
+    - agg_record


### PR DESCRIPTION
This pull request is an attempt to fix this failure on CI.

https://github.com/r-lib/ragg/actions/runs/13788588896/job/38562367647#step:6:303
```
 ✖ Reference metadata not ok.
  In _pkgdown.yml, 1 topic missing from index: "agg_record".
  Either use `@keywords internal` to drop from index, or
```