### PR TITLE
webp: minor doc fix, improved error handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ Config/testthat/edition: 3
 Config/usethis/last-upkeep: 2025-04-25
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 SystemRequirements: freetype2, libpng, libtiff, libjpeg, libwebp, libwebpmux

--- a/R/agg_dev.R
+++ b/R/agg_dev.R
@@ -603,7 +603,6 @@ agg_webp <- function(
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' file <- tempfile(fileext = '.webp')
 #' agg_webp_anim(file, delay = 100, loop = 0)
 #' for(i in 1:10) {
@@ -611,7 +610,6 @@ agg_webp <- function(
 #'   dev.flush()
 #' }
 #' dev.off()
-#' }
 agg_webp_anim <- function(
   filename   = 'Ranim.webp',
   width      = 480,

--- a/man/agg_webp_anim.Rd
+++ b/man/agg_webp_anim.Rd
@@ -68,7 +68,6 @@ The WebP format is a raster image format that provides improved lossless (and
 lossy) compression for images on the web. Transparency is supported.
 }
 \examples{
-\dontrun{
 file <- tempfile(fileext = '.webp')
 agg_webp_anim(file, delay = 100, loop = 0)
 for(i in 1:10) {
@@ -76,7 +75,6 @@ for(i in 1:10) {
   dev.flush()
 }
 dev.off()
-}
 }
 \seealso{
 \code{\link[=agg_webp]{agg_webp()}} for static WebP images

--- a/src/init_device.h
+++ b/src/init_device.h
@@ -2,6 +2,7 @@
 
 #include "ragg.h"
 #include <cstddef>
+#include <memory>
 
 template<class T>
 void agg_metric_info(int c, const pGEcontext gc, double* ascent,
@@ -43,8 +44,15 @@ void agg_close(pDevDesc dd) {
   T * device = (T *) dd->deviceSpecific;
 
   BEGIN_CPP
+  auto deleter = [dd](T* ptr) {
+    if (dd != NULL) {
+      dd->deviceSpecific = NULL;
+    }
+    delete ptr;
+  };
+  std::unique_ptr<T, decltype(deleter)> guard(device, deleter);
   device->close();
-  delete device;
+  guard.reset();
   END_CPP
 
   return;


### PR DESCRIPTION
Minor change:

- gets rid of the dontrun tag that seems to break the rendered docs (see https://ragg.r-lib.org/reference/agg_webp_anim.html#ref-examples) 
- adds slightly more robust error and memory handling.
