### PR TITLE
Avoid advancing RNG when creating agg devices

### DIFF
--- a/R/agg_dev.R
+++ b/R/agg_dev.R
@@ -427,7 +427,7 @@ agg_capture <- function(
   }
   dim <- get_dims(width, height, units, res)
   background <- if (missing(bg)) background else bg
-  name <- paste0('agg_capture_', sample(.Machine$integer.max, 1))
+  name <- basename(tempfile('agg_capture_'))
   .Call(
     "agg_capture_c",
     name,
@@ -504,7 +504,7 @@ agg_record <- function(
   }
   dim <- get_dims(width, height, units, res)
   background <- if (missing(bg)) background else bg
-  name <- paste0('agg_record_', sample(.Machine$integer.max, 1))
+  name <- basename(tempfile('agg_record_'))
   .Call(
     "agg_record_c",
     name,

--- a/tests/testthat/test-rng-state.R
+++ b/tests/testthat/test-rng-state.R
@@ -1,0 +1,32 @@
+test_that("agg devices do not advance global RNG state on creation", {
+
+  set.seed(123)
+  dev <- agg_capture()
+  handle <- dev()
+  dev.off()
+  a1 <- runif(1)
+  b1 <- .Random.seed
+
+  set.seed(123)
+  a2 <- runif(1)
+  b2 <- .Random.seed
+
+  expect_equal(a1, a2)
+  expect_equal(b1, b2)
+})
+
+test_that("agg_record does not advance global RNG state on creation", {
+  # with ragg
+  set.seed(456)
+  agg_record()
+  dev.off()
+  a1 <- runif(1)
+  b1 <- .Random.seed
+
+  set.seed(456)
+  a2 <- runif(1)
+  b2 <- .Random.seed
+
+  expect_equal(a1, a2)
+  expect_equal(b1, b2)
+})


### PR DESCRIPTION
## Summary

This PR replaces RNG-based device naming (`sample()`) with `tempfile()`-based names so that creating agg devices no longer advances the global RNG state.

## Motivation

Device creation currently mutates `.Random.seed`, which can be surprising in reproducible workflows. This can also make whitespace semantically meaningful in downstream jupyter contexts, e.g., latest containerized `jupyter/datascience-notebook`. 

## Changes

- Use `basename(tempfile())` to generate unique device names without touching RNG state
- Add tests asserting that `agg_capture()` and `agg_record()` do not advance the global RNG

## Notes

- `tempfile()` does not create files and does not use or modify `.Random.seed`
- Behavior is unchanged except for the removal of RNG side effects during device creation
